### PR TITLE
Fix: Change Android package name as it can cause conflict with other …

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.reactlibrary.reactnativecompasheading">
 
 </manifest>


### PR DESCRIPTION
I had the following error when building on Android:

```
> Task :app:transformClassesWithMultidexlistForDebug FAILED
D8: Program type already present: com.reactlibrary.BuildConfig
```

Changing package name to more unique resolved the issue.