### PR TITLE
Fix RN 0.65 warnings due to missing method.

### DIFF
--- a/android/src/main/java/com/reactlibrary/compassheading/CompassHeadingModule.java
+++ b/android/src/main/java/com/reactlibrary/compassheading/CompassHeadingModule.java
@@ -54,6 +54,16 @@ public class CompassHeadingModule extends ReactContextBaseJavaModule implements 
     }
 
     @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
     public void start(int filter, Promise promise) {
 
         try{


### PR DESCRIPTION
Adds required stubs on Android to silence a module warning included in RN 0.65