### PR TITLE
supporting react >=17.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-compass-heading",
   "title": "React Native Compass Heading",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Listener to device's compass information.",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^17.0.2",
+    "react": ">=17.0.2",
     "react-native": ">=0.60.0 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
When trying to install with a new created project I get the following error

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: testapp@0.0.1
npm ERR! Found: react@18.1.0
npm ERR! node_modules/react
npm ERR!   react@"18.1.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.2" from react-native-compass-heading@1.4.1
npm ERR! node_modules/react-native-compass-heading
npm ERR!   react-native-compass-heading@"*" from the root project
```
Create this PR, but I dont know which will be the last version to support? I suggest react >=17.0.2 would be ok?

Thanks!
